### PR TITLE
Feat/admin show total invoice revenue 2

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -15,4 +15,10 @@ class Invoice < ApplicationRecord
     .where.not("invoice_items.status = ?", 2)
     .order(:created_at)
   end
+
+  def total_invoice_revenue
+    items
+    .joins(:invoice_items)
+    .sum("invoice_items.unit_price * invoice_items.quantity")
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -21,4 +21,10 @@ class Invoice < ApplicationRecord
     .joins(:invoice_items)
     .sum("invoice_items.unit_price * invoice_items.quantity")
   end
+
+  def total_invoice_revenue_dollars 
+    total_invoice_revenue.to_f / 100
+  end
+
+
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -25,6 +25,4 @@ class Invoice < ApplicationRecord
   def total_invoice_revenue_dollars 
     total_invoice_revenue.to_f / 100
   end
-
-
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -4,7 +4,7 @@
 <p> Status: <%= @invoice.status %> </p>
 <p> Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
 <p> Total Revenue: $<%= @invoice.total_invoice_revenue_dollars %>
-<p> <h3> Customer: <h3> <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %> </p>
+<p> <h3> Customer: </h3> <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %> </p>
 </section>
 
 <br>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -3,6 +3,7 @@
 
 <p> Status: <%= @invoice.status %> </p>
 <p> Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
+<p> Total Revenue: $<%= @invoice.total_invoice_revenue_dollars %>
 <p> <h3> Customer: <h3> <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %> </p>
 </section>
 

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -3,7 +3,7 @@
 
 <p> Status: <%= @invoice.status %> </p>
 <p> Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
-<p> Total Revenue: $<%= @invoice.total_invoice_revenue_dollars %>
+<p> Total Revenue: $<%= number_with_precision(@invoice.total_invoice_revenue_dollars, precision: 2, delimiter: ",") %>
 <p> <h3> Customer: </h3> <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %> </p>
 </section>
 
@@ -15,7 +15,7 @@
 <div id="inv_item_<%=ii.id %>">   
   <h3> Item: <%= ii.item.name %> </h3>
   <p> Quantity Ordered: <%= ii.quantity %> </p>
-  <p> Unit Price $<%= ii.item.current_price %> </p>
+  <p> Unit Price $<%= number_with_precision(ii.item.current_price, precision: 2, delimiter: ",") %> </p>
   <p> Item Status: <%= ii.status %> </p>
 </div>
 

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,8 +2,8 @@
 <h1> Invoice #<%=@invoice.id%> </h1>
 
 <p> Status: <%= @invoice.status %> </p>
-<p> Invoice Date: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
-<p> Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %> </p>
+<p> Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
+<p> <h3> Customer: <h3> <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %> </p>
 </section>
 
 <br>
@@ -14,7 +14,7 @@
 <div id="inv_item_<%=ii.id %>">   
   <h3> Item: <%= ii.item.name %> </h3>
   <p> Quantity Ordered: <%= ii.quantity %> </p>
-  <p> Price Per Unit: <%= ii.unit_price %> </p>
+  <p> Unit Price $<%= ii.item.current_price %> </p>
   <p> Item Status: <%= ii.status %> </p>
 </div>
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'The Admin Invoice Show' do
     @inv_items_0 = create_list(:invoice_item, 5, invoice: @invoices[0])
     @inv_items_1 = create_list(:invoice_item, 5, invoice: @invoices[1])
     @inv_items_2 = create_list(:invoice_item, 5, invoice: @invoices[2])
-    
     visit admin_invoice_path(@invoices[0])
   end
   
@@ -68,7 +67,6 @@ RSpec.describe 'The Admin Invoice Show' do
         @inv_items_1.each do |ii|
           within("#inv_item_#{ii.id}") do
             expect(page).to have_content(ii.quantity)
-            expect(page).to_not have_content(@inv_items_0[2].quantity)
           end
         end
       end
@@ -76,10 +74,11 @@ RSpec.describe 'The Admin Invoice Show' do
 
     it 'shows all invoice item prices' do
       visit admin_invoice_path(@invoices[2])
+      save_and_open_page
       within("#all_invoice_items") do
         @inv_items_2.each do |ii|
           within("#inv_item_#{ii.id}") do
-            expect(page).to have_content(ii.unit_price)
+            expect(page).to have_content(ii.item.current_price)
             expect(page).to_not have_content(@inv_items_0[3].unit_price)
           end
         end
@@ -97,4 +96,9 @@ RSpec.describe 'The Admin Invoice Show' do
       end
     end
   end
+
+  describe 'total revenue section' do
+
+  end
+
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe 'The Admin Invoice Show' do
     @inv_items_1 = create_list(:invoice_item, 5, invoice: @invoices[1])
     @inv_items_2 = create_list(:invoice_item, 5, invoice: @invoices[2])
     visit admin_invoice_path(@invoices[0])
+
+    @inv_extra = create(:invoice)
+    @inv_extra_inv_items = create_list(:invoice_item, 3, unit_price: 500, invoice: @inv_extra, quantity: 2)
   end
   
   describe 'invoice info section' do
@@ -49,11 +52,9 @@ RSpec.describe 'The Admin Invoice Show' do
     end
 
     it 'shows the total revenue in dollars' do
+      visit admin_invoice_path(@inv_extra)
       within("#invoice_info") do
-        @invoices.each do |inv|
-          visit admin_invoice_path(inv)
-          expect(page).to have_content(inv.total_invoice_revenue_dollars)
-        end
+        expect(page).to have_content("Total Revenue: $30.00")
       end
     end
   end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe 'The Admin Invoice Show' do
 
     it 'shows all invoice item prices' do
       visit admin_invoice_path(@invoices[2])
-      save_and_open_page
       within("#all_invoice_items") do
         @inv_items_2.each do |ii|
           within("#inv_item_#{ii.id}") do

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe 'The Admin Invoice Show' do
         end
       end
     end
+
+    it 'shows the total revenue in dollars' do
+      within("#invoice_info") do
+        @invoices.each do |inv|
+          visit admin_invoice_path(inv)
+          expect(page).to have_content(inv.total_invoice_revenue_dollars)
+        end
+      end
+    end
   end
 
   describe 'invoice item information section' do
@@ -96,9 +105,4 @@ RSpec.describe 'The Admin Invoice Show' do
       end
     end
   end
-
-  describe 'total revenue section' do
-
-  end
-
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe Invoice, type: :model do
       end
 
       it 'orders invoices with invoice items that have not been shipped by date' do
-        oldest_inv = create(:invoice, created_at: Date.yesterday)
+        oldest_inv = create(:invoice, created_at: 2.day.ago)
         middle_inv = create(:invoice, created_at: Date.today)
         newest_inv = create(:invoice, created_at: Date.tomorrow)
-
+        
         oldest_inv_items = create_list(:invoice_item, 5, invoice: oldest_inv, status: 1)
         middle_inv_items = create_list(:invoice_item, 5, invoice: middle_inv, status: 0)
         newest_inv_items = create_list(:invoice_item, 5, invoice: newest_inv, status: 1)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -69,4 +69,20 @@ RSpec.describe Invoice, type: :model do
       end
     end
   end
+
+  describe 'instance methods' do
+    describe '#total_invoice_revenue' do
+      it 'calculates the total invoice revenue' do
+        invoices = create_list(:invoice, 3)
+
+        inv_items_0 = create_list(:invoice_item, 3, invoice: invoices[0], unit_price: 1000, quantity: 1)
+        inv_items_1 = create_list(:invoice_item, 3, invoice: invoices[1], unit_price: 2000, quantity: 2)
+        inv_items_2 = create_list(:invoice_item, 3, invoice: invoices[2], unit_price: 3000, quantity: 3)
+        
+        expect(invoices[0].total_invoice_revenue).to eq(3000)
+        expect(invoices[1].total_invoice_revenue).to eq(12000)
+        expect(invoices[2].total_invoice_revenue).to eq(27000)
+      end
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -84,5 +84,17 @@ RSpec.describe Invoice, type: :model do
         expect(invoices[2].total_invoice_revenue).to eq(27000)
       end
     end
+
+    it 'calculates total invoice revenue in dollars' do
+      invoices = create_list(:invoice, 3)
+
+      inv_items_0 = create_list(:invoice_item, 3, invoice: invoices[0], unit_price: 1000, quantity: 1)
+      inv_items_1 = create_list(:invoice_item, 3, invoice: invoices[1], unit_price: 2000, quantity: 2)
+      inv_items_2 = create_list(:invoice_item, 3, invoice: invoices[2], unit_price: 3000, quantity: 3)
+      
+      expect(invoices[0].total_invoice_revenue_dollars).to eq(30.00)
+      expect(invoices[1].total_invoice_revenue_dollars).to eq(120.00)
+      expect(invoices[2].total_invoice_revenue_dollars).to eq(270.00)
+    end
   end
 end


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_
Display of total invoice revenue in dollars on Admin Invoice show page
## Solution
_How did you solve the problem?_
Invoice model instance methods total_invoice_revenue and total_invoice_revenue dollars/associated tests
Add line for total revenue to Admin Invoice Show page in invoice_info section/associated test
## Other changes (e.g. bug fixes, UI tweaks, small refactors)
FE updates to admin invoice show page to match wireframe more closely
Fix test in invoice model spec to not fail
Candace's requested updates: number_with_precision
## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary